### PR TITLE
Added support for more Proxmox versions and test files

### DIFF
--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEBIAN_CODENAME=`cat /etc/os-release | grep VERSION_CODENAME | cut -d "=" -f2`
+DEBIAN_CODENAME=$(cat /etc/os-release | grep VERSION_CODENAME | cut -d "=" -f2)
 ENTERPRISE_REPO_LIST="/etc/apt/sources.list.d/pve-enterprise.list"
 FREE_REPO_FILE="/etc/apt/sources.list.d/pve.list"
 FREE_REPO_LIST=$(cat <<-EOF
@@ -16,13 +16,13 @@ function pve_patch() {
   echo "$FREE_REPO_LIST" > $FREE_REPO_FILE
   [ -f $ENTERPRISE_REPO_LIST ] && mv $ENTERPRISE_REPO_LIST $ENTERPRISE_REPO_LIST~
   # (6.1 and up)
-  sed -i "s|if (data.status !== 'Active')|if (false)|g" $JSLIBFILE
+  sed -i "s|if (data.status !== 'Active')|if (false)|g" ${JSLIBFILE}
   # (6.2-11 and up)
   sed -i -z "s/res.*res.*.false/false/g" $JSLIBFILE
   # (6.2-12 and up)
-  sed -i -z "s/res.*res.*.data.status !== 'Active'/false/g" $JSLIBFILE
+  sed -i -z "s/res.*res.*.data.status !== 'Active'/false/g" ${JSLIBFILE}
   # (6.2-15 6.3-2 6.3-3 6.3-4 6.3-6 and up)
-  sed -i -z "s/res.*res.*.data.status.toLowerCase() !== 'active'/false/g" $JSLIBFILE
+  sed -i -z "s/res.*res.*.data.status.toLowerCase() !== 'active'/false/g" ${JSLIBFILE}
 }
 
 pve_patch

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -25,6 +25,7 @@ function pve_patch() {
   sed -i -z "s/REPLACEME.*data.status !== 'Active'/false/" ${JSLIBFILE}
   # (6.2-15 6.3-2 6.3-3 6.3-4 6.3-6 and up)
   sed -i -z "s/REPLACEME.*.data.status.toLowerCase() !== 'active'/false/" ${JSLIBFILE}
+  systemctl restart pveproxy.service
   
 }
 

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -15,8 +15,14 @@ function pve_patch() {
   echo "- apply patch..."
   echo "$FREE_REPO_LIST" > $FREE_REPO_FILE
   [ -f $ENTERPRISE_REPO_LIST ] && mv $ENTERPRISE_REPO_LIST $ENTERPRISE_REPO_LIST~
-  grep -q "data.status !== 'Active'" $JSLIBFILE &&
-    sed -i.bak "s/data.status !== 'Active'/false/g" $JSLIBFILE
+  # (6.1 and up)
+  sed -i "s|if (data.status !== 'Active')|if (false)|g" $JSLIBFILE
+  # (6.2-11 and up)
+  sed -i -z "s/res.*res.*.false/false/g" $JSLIBFILE
+  # (6.2-12 and up)
+  sed -i -z "s/res.*res.*.data.status !== 'Active'/false/g" $JSLIBFILE
+  # (6.2-15 6.3-2 6.3-3 6.3-4 6.3-6 and up)
+  sed -i -z "s/res.*res.*.data.status.toLowerCase() !== 'active'/false/g" $JSLIBFILE
 }
 
 pve_patch

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -16,15 +16,13 @@ function pve_patch() {
   echo "$FREE_REPO_LIST" > $FREE_REPO_FILE
   [ -f $ENTERPRISE_REPO_LIST ] && mv $ENTERPRISE_REPO_LIST $ENTERPRISE_REPO_LIST~
   # (6.1 and up)
-  sed -i "s|if (data.status !== 'Active')|if (false)|g" ${JSLIBFILE}
-  # Anchor so we can safely replace what we want for multiline
-  sed -i 's|res === null \|\| res === undefined \|\| \!res \|\| res|REPLACEME|' ${JSLIBFILE}
+  sed -i.backup "s/data.status !== 'Active'/false/g" ${JSLIBFILE}
   # (6.2-11 and up)
-  sed -i -z "s/REPLACEME.*.false/false/" ${JSLIBFILE}
+  sed -i.backup -z "s/res === null || res === undefined || \!res || res\n\t\t\t.false/false/g" ${JSLIBFILE}
   # (6.2-12 and up)
-  sed -i -z "s/REPLACEME.*data.status !== 'Active'/false/" ${JSLIBFILE}
+  sed -i.backup -z "s/res === null || res === undefined || \!res || res\n\t\t\t.data.status \!== 'Active'/false/g" ${JSLIBFILE}
   # (6.2-15 6.3-2 6.3-3 6.3-4 6.3-6 and up)
-  sed -i -z "s/REPLACEME.*.data.status.toLowerCase() !== 'active'/false/" ${JSLIBFILE}
+  sed -i.backup -z "s/res === null || res === undefined || \!res || res\n\t\t\t.data.status.toLowerCase() \!== 'active'/false/g" ${JSLIBFILE}
   systemctl restart pveproxy.service
   
 }

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -17,12 +17,15 @@ function pve_patch() {
   [ -f $ENTERPRISE_REPO_LIST ] && mv $ENTERPRISE_REPO_LIST $ENTERPRISE_REPO_LIST~
   # (6.1 and up)
   sed -i "s|if (data.status !== 'Active')|if (false)|g" ${JSLIBFILE}
+  # Anchor so we can safely replace what we want for multiline
+  sed -i 's|res === null \|\| res === undefined \|\| \!res \|\| res|REPLACEME|' ${JSLIBFILE}
   # (6.2-11 and up)
-  sed -i -z "s/res.*res.*.false/false/g" $JSLIBFILE
+  sed -i -z "s/REPLACEME.*.false/false/" ${JSLIBFILE}
   # (6.2-12 and up)
-  sed -i -z "s/res.*res.*.data.status !== 'Active'/false/g" ${JSLIBFILE}
+  sed -i -z "s/REPLACEME.*data.status !== 'Active'/false/" ${JSLIBFILE}
   # (6.2-15 6.3-2 6.3-3 6.3-4 6.3-6 and up)
-  sed -i -z "s/res.*res.*.data.status.toLowerCase() !== 'active'/false/g" ${JSLIBFILE}
+  sed -i -z "s/REPLACEME.*.data.status.toLowerCase() !== 'active'/false/" ${JSLIBFILE}
+  
 }
 
 pve_patch

--- a/scripts/patch-test.sh
+++ b/scripts/patch-test.sh
@@ -18,5 +18,5 @@ diff -y ${TESTFILE} ${CONTROLFILE}
 echo '===================================================='
 echo "Run the below to reset the ${TESTFILE} file after replacements with ${ORIGINALFILE}"
 echo '===================================================='
-rm -f "${TESTFILE}" && cp "${ORIGINALFILE}" "${TESTFILE}"
+echo "rm -f ${TESTFILE} && cp ${ORIGINALFILE} ${TESTFILE}"
 echo '===================================================='

--- a/scripts/patch-test.sh
+++ b/scripts/patch-test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+CONTROLFILE='proxmox-patch-tests-control.txt'
+ORIGINALFILE='proxmox-patch-tests-original.txt'
+TESTFILE='proxmox-patch-tests.txt'
+sed -i "s|if (data.status !== 'Active')|if (false)|g" ${TESTFILE}
+sed -i -z "s/res.*res.*.false/false/g" ${TESTFILE}
+sed -i -z "s/res.*res.*.data.status !== 'Active'/false/g" ${TESTFILE}
+sed -i -z "s/res.*res.*.data.status.toLowerCase() !== 'active'/false/g" ${TESTFILE}
+
+echo "Comparing ${TESTFILE} file after replacements with ${ORIGINALFILE}"
+echo '===================================================='
+diff -y ${TESTFILE} ${ORIGINALFILE}
+echo '===================================================='
+
+echo "Comparing ${TESTFILE} file after replacements with ${CONTROLFILE}"
+echo '===================================================='
+diff -y ${TESTFILE} ${CONTROLFILE}
+echo '===================================================='
+echo "Run the below to reset the ${TESTFILE} file after replacements with ${ORIGINALFILE}"
+echo '===================================================='
+rm -f "${TESTFILE}" && cp "${ORIGINALFILE}" "${TESTFILE}"
+echo '===================================================='

--- a/scripts/patch-test.sh
+++ b/scripts/patch-test.sh
@@ -3,9 +3,9 @@ CONTROLFILE='proxmox-patch-tests-control.txt'
 ORIGINALFILE='proxmox-patch-tests-original.txt'
 TESTFILE='proxmox-patch-tests.txt'
 sed -i "s|if (data.status !== 'Active')|if (false)|g" ${TESTFILE}
-sed -i -z "s/res.*res.*.false/false/g" ${TESTFILE}
-sed -i -z "s/res.*res.*.data.status !== 'Active'/false/g" ${TESTFILE}
-sed -i -z "s/res.*res.*.data.status.toLowerCase() !== 'active'/false/g" ${TESTFILE}
+sed -i 's|res === null \|\| res === undefined \|\| \!res \|\| res|REPLACEME|' ${TESTFILE}
+sed -i -z "s/REPLACEME.*.data.status.toLowerCase() !== 'active'/false/" ${TESTFILE}
+sed -i -z "s/REPLACEME.*data.status !== 'Active'/false/" ${TESTFILE}
 
 echo "Comparing ${TESTFILE} file after replacements with ${ORIGINALFILE}"
 echo '===================================================='

--- a/scripts/patch-test.sh
+++ b/scripts/patch-test.sh
@@ -2,10 +2,10 @@
 CONTROLFILE='proxmox-patch-tests-control.txt'
 ORIGINALFILE='proxmox-patch-tests-original.txt'
 TESTFILE='proxmox-patch-tests.txt'
-sed -i "s|if (data.status !== 'Active')|if (false)|g" ${TESTFILE}
-sed -i 's|res === null \|\| res === undefined \|\| \!res \|\| res|REPLACEME|' ${TESTFILE}
-sed -i -z "s/REPLACEME.*.data.status.toLowerCase() !== 'active'/false/" ${TESTFILE}
-sed -i -z "s/REPLACEME.*data.status !== 'Active'/false/" ${TESTFILE}
+sed -i.backup "s/data.status !== 'Active'/false/g" ${TESTFILE}
+sed -i.backup -z "s/res === null || res === undefined || \!res || res\n\t\t\t.false/false/g"${TESTFILE}
+sed -i.backup -z "s/res === null || res === undefined || \!res || res\n\t\t\t.data.status \!== 'Active'/false/g" ${TESTFILE}
+sed -i.backup -z "s/res === null || res === undefined || \!res || res\n\t\t\t.data.status.toLowerCase() \!== 'active'/false/g" ${TESTFILE}
 
 echo "Comparing ${TESTFILE} file after replacements with ${ORIGINALFILE}"
 echo '===================================================='
@@ -20,3 +20,4 @@ echo "Run the below to reset the ${TESTFILE} file after replacements with ${ORIG
 echo '===================================================='
 echo "rm -f ${TESTFILE} && cp ${ORIGINALFILE} ${TESTFILE}"
 echo '===================================================='
+

--- a/scripts/proxmox-patch-tests-control.txt
+++ b/scripts/proxmox-patch-tests-control.txt
@@ -1,0 +1,11 @@
+# (6.1 and up)
+if (false) {
+
+# (6.2-11 and up)
+if (false) {
+
+# (6.2-12 and up)
+if (false) {
+
+# (6.2-15 6.3-2 6.3-3 6.3-4 6.3-6 and up)
+if (false) {

--- a/scripts/proxmox-patch-tests-original.txt
+++ b/scripts/proxmox-patch-tests-original.txt
@@ -1,0 +1,15 @@
+# (6.1 and up)
+if (data.status !== 'Active') {
+
+# (6.2-11 and up)
+if (res === null || res === undefined || !res || res
+			.false) {
+
+# (6.2-12 and up)
+if (res === null || res === undefined || !res || res
+			.data.status !== 'Active') {
+
+# (6.2-15 6.3-2 6.3-3 6.3-4 6.3-6 and up)
+if (res === null || res === undefined || !res || res
+			.data.status.toLowerCase() !== 'active') {
+

--- a/scripts/proxmox-patch-tests.txt
+++ b/scripts/proxmox-patch-tests.txt
@@ -1,0 +1,14 @@
+# (6.1 and up)
+if (data.status !== 'Active') {
+
+# (6.2-11 and up)
+if (res === null || res === undefined || !res || res
+			.false) {
+
+# (6.2-12 and up)
+if (res === null || res === undefined || !res || res
+			.data.status !== 'Active') {
+
+# (6.2-15 6.3-2 6.3-3 6.3-4 6.3-6 and up)
+if (res === null || res === undefined || !res || res
+			.data.status.toLowerCase() !== 'active') {


### PR DESCRIPTION
This accounts for all cases without overlap and catches some subtle cases where the one existing sed would fail.

If you wanted to be super selective you could check the version and add logic to do it based on version but that seems overkill
`pveversion | sed 's|pve-manager/||'|awk -F'/' '{print $1}'`

See this for reference:
https://dannyda.com/2020/05/17/how-to-remove-you-do-not-have-a-valid-subscription-for-this-server-from-proxmox-virtual-environment-6-1-2-proxmox-ve-6-1-2-pve-6-1-2/

Test also included so you can see it locally in action. :)
`bash patch-test.sh`
![image](https://user-images.githubusercontent.com/1596188/115154538-5390fe00-a049-11eb-9ac5-577bf1c28727.png)

